### PR TITLE
décorrélation des passwords persisté et affichés

### DIFF
--- a/src/Controller/Admin/UserCrudController.php
+++ b/src/Controller/Admin/UserCrudController.php
@@ -4,10 +4,6 @@ namespace App\Controller\Admin;
 
 use App\Entity\User;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
-use EasyCorp\Bundle\EasyAdminBundle\Field\ArrayField;
-use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
-use EasyCorp\Bundle\EasyAdminBundle\Field\EmailField;
-use EasyCorp\Bundle\EasyAdminBundle\Field\IdField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 
@@ -18,14 +14,21 @@ class UserCrudController extends AbstractCrudController
         return User::class;
     }
 
-    /*
     public function configureFields(string $pageName): iterable
     {
-        return [
-            IdField::new('id'),
-            TextField::new('title'),
-            TextEditorField::new('description'),
-        ];
+        $out = [ TextField::new('email') ];
+
+        if ($pageName !== 'index') {
+            $out[] = TextField::new('plainPassword')
+                ->setLabel('Password')
+                ->setFormType(PasswordType::class)
+                ->setRequired($pageName === 'new');
+        }
+
+        return array_merge($out, [
+            TextField::new('lastName'),
+            TextField::new('firstName'),
+            TextField::new('function'),
+        ]);
     }
-    */
 }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -28,6 +28,8 @@ class User implements UserInterface
      */
     private $roles = [];
 
+    private $plainPassword;
+
     /**
      * @var string The hashed password
      * @ORM\Column(type="string")
@@ -91,6 +93,18 @@ class User implements UserInterface
     public function setRoles(array $roles): self
     {
         $this->roles = $roles;
+
+        return $this;
+    }
+
+    public function getPlainPassword()
+    {
+        return $this->plainPassword;
+    }
+
+    public function setPlainPassword($plainPassword)
+    {
+        $this->plainPassword = $plainPassword;
 
         return $this;
     }

--- a/src/EventSubscriber/EasyAdminSubscriber.php
+++ b/src/EventSubscriber/EasyAdminSubscriber.php
@@ -54,7 +54,11 @@ class EasyAdminSubscriber implements EventSubscriberInterface
      */
     public function setPassword(User $entity): void
     {
-        $pass = $entity->getPassword();
+        $pass = $entity->getPlainPassword();
+
+        if (!$pass) {
+            return;
+        }
 
         $entity->setPassword($this->passwordEncoder->encodePassword($entity, $pass));
         $this->entityManager->persist($entity);


### PR DESCRIPTION
- Ajout d'un champ "plainPassword" qui n'est pas rattaché à une colonne en base
- Utilisation de ce champ dans ce qui est transmis à easyadmin
- Configuration de ce champ pour que ce soit un input HTML mot de passe et non texte plein
- Configuration de ce champ pour qu'il ne soit requis qu'à la création
- Configuration de ce champ pour qu'il ne soit pas affiché sur le listing
- Mise à jour du listener pour qu'il n'encode et persiste le mot de passe en base (champ "password") que s'il a été saisi (dans "plainPassword"